### PR TITLE
solved 소수구하기 - 160ms 2mb

### DIFF
--- a/Baekjoon/소수구하기/소수구하기_조은영.cpp
+++ b/Baekjoon/소수구하기/소수구하기_조은영.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+
+	int N = 0, M = 0;
+
+	cin >> N >> M;
+
+	for (int i = N; i <= M; i++) {
+		int cnt = 0;
+
+		if (i == 1) continue;
+
+		for (int j = 1; j*j <= i; j++) {
+			if (i % j == 0) cnt++;
+			if (cnt > 1) break;
+		}
+
+		if (cnt == 1) cout << i << "\n";
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#125 

## 📝 풀이 후기
쉬웠습니다.

## 📚 문제 풀이 핵심 키워드
- 데이터 개수가 많아 이중for문을 그대로 사용하면 시간초과가 발생합니다. 약수는 a*b의 형식으로 이루어져있기 때문에 a만 검사해도 됩니다. 따라서 for문의 조건을 i*i<=j로 하면 반복을 줄일 수 있습니다.

## 🤔 리뷰로 궁금한 점


## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?
